### PR TITLE
Add an environment variable to avoid errors of scatter_dataset

### DIFF
--- a/scripts/install-chainermn.sh
+++ b/scripts/install-chainermn.sh
@@ -17,6 +17,7 @@ if grep -q "I_MPI" ~/.bashrc; then :; else
   echo 'export I_MPI_DAPL_PROVIDER=ofa-v2-ib0' >> ~/.bashrc
   echo 'export I_MPI_DYNAMIC_CONNECTION=0' >> ~/.bashrc
   echo 'export I_MPI_FALLBACK_DEVICE=0' >> ~/.bashrc
+  echo 'export I_MPI_DAPL_TRANSLATION_CACHE=0' >> ~/.bashrc
   echo 'export PATH=/usr/local/cuda/bin:$PATH' >> ~/.bashrc
   echo 'source /opt/intel/compilers_and_libraries_2017.4.196/linux/mpi/intel64/bin/mpivars.sh' >> ~/.bashrc
 fi


### PR DESCRIPTION
`export I_MPI_DAPL_TRANSLATION_CACHE=0` should be set.