### PR TITLE
Use larger instance for Jumpbox

### DIFF
--- a/deploy-jumpbox.json
+++ b/deploy-jumpbox.json
@@ -7,7 +7,7 @@
     },
     "virtualMachineSize": {
       "type": "string",
-      "defaultValue": "Standard_DS3_v2",
+      "defaultValue": "Standard_L8s",
       "allowedValues": [
         "Standard_DS1",
         "Standard_DS2",


### PR DESCRIPTION
Usually, the dataset which is used for the training is put at the disk on the jumpbox node by sharing it among all worker nodes. So, the larger default VM size is better.